### PR TITLE
Fix key sequence event passthrough etc

### DIFF
--- a/nkms/core/event_handler.py
+++ b/nkms/core/event_handler.py
@@ -1,0 +1,188 @@
+from enum import IntEnum
+from typing import Final
+
+from evdev import InputEvent, UInput, ecodes
+from json import dumps as json_dumps
+from select import select
+from threading import Lock
+
+from nkms.core.settings import NkmsSettings
+from nkms.utils.udp_socket import UdpSocket
+
+SERVER_CLIENT_INDEX: Final = -1
+CLIENT_ACTIVITY_TIMEOUT: Final = 5  # drop clients after 5 seconds with no pings.
+
+
+class KeyEventType(IntEnum):
+    KEY_UP = 0
+    KEY_DOWN = 1
+    KEY_REPEAT = 2
+
+
+class EventHandler:
+
+    def __init__(
+            self,
+            settings: NkmsSettings,
+            device_capabilities: dict,
+    ):
+        self.settings = settings
+        self.clients = []
+        self.client_lock = Lock()
+        self.data_port = self.settings.server_port + 1  # use the next higher port
+        self.sock = UdpSocket(timeout=2)
+        self.running = True
+        self.client_index = SERVER_CLIENT_INDEX
+        self.keys_activated = False
+        self.key1_down = False
+        self.key2_down = False
+        self.prevented_key1_press = False
+        self.uinput = UInput(
+            events=device_capabilities,
+            name='NetKMSwitch Keyboard and Mouse',
+        )
+
+    def add_client(self, client):
+        """Add a client to the clients list."""
+        with self.client_lock:
+            if client not in self.clients:
+                self.clients.append(client)
+
+    def remove_client(self, client):
+        """Remove a client from the clients list."""
+        with self.client_lock:
+            if client in self.clients:
+                should_get_next = self.client_index == self.clients.index(client)
+                self.clients.remove(client)
+                if should_get_next:
+                    self.get_next_client()
+
+    def get_next_client(self):
+        """Set socket_index to next value to cycle through outputs."""
+        if self.client_index >= len(self.clients) - 1:
+            self.client_index = SERVER_CLIENT_INDEX
+        else:
+            self.client_index = self.client_index + 1
+
+    def _maybe_get_next_client(self, key_code: int) -> bool:
+        """Go to next client if switch key sequence has been pressed."""
+        got_next_client = False
+        if key_code == self.settings.server_key1:
+            if (
+                self.key1_down and  # key1 is releasing
+                (
+                    self.settings.server_key2 == 0 or  # key2 is undefined or
+                    (self.keys_activated and not self.key2_down)  # key2 was pressed and released
+                )
+            ):
+                # without key2: key1 was pressed, and is now releasing
+                # with key2: key1 was pressed, key2 was pressed, key2 was released, key1 is now releasing
+                self.get_next_client()
+                self.keys_activated = False
+                got_next_client = True
+
+            self.key1_down = not self.key1_down
+
+        elif key_code == self.settings.server_key2:
+            if self.key2_down and self.keys_activated and not self.key1_down:
+                # key1 was pressed, key2 was pressed, key1 released, now key2 is releasing
+                self.get_next_client()
+                self.keys_activated = False
+                got_next_client = True
+
+            if self.key1_down:
+                self.keys_activated = True
+
+            self.key2_down = not self.key2_down
+
+        return got_next_client
+
+    def _send_event_to_client(self, event) -> None:
+        """Send event to client."""
+        if self.client_index == SERVER_CLIENT_INDEX:
+            self.uinput.write_event(event)
+            self.uinput.syn()
+            return
+
+        with self.client_lock:  # Protect clients list access
+            if self.clients:
+                client = self.clients[self.client_index]
+                try:
+                    self.sock.send_string_to(
+                        string=f"{json_dumps([event.type, event.code, event.value])}\n",
+                        to=(client, self.data_port),
+                    )
+                except OSError as e:
+                    print(f'Error sending to {client}: {e!s}')
+                    self.clients.remove(client)
+                    self.get_next_client()
+
+    def _make_key1_press_from_event(self, event: InputEvent) -> InputEvent:
+        """Create a key1 press event to immediately precede the given event."""
+        return InputEvent(
+            sec=event.sec,
+            usec=event.usec - 1,
+            type=ecodes.EV_KEY,
+            code=self.settings.server_key1,
+            value=KeyEventType.KEY_DOWN,
+        )
+
+    def _process_event(self, event: InputEvent) -> bool:
+        """Process a key event.
+        Returns True if the event should be passed to the client, False if it should be ignored.
+        """
+        if (
+            event.type != ecodes.EV_KEY or
+            event.value not in (KeyEventType.KEY_UP, KeyEventType.KEY_DOWN)
+        ):
+            return True  # We only care about special processing on up/down key events.
+
+        if event.code in (self.settings.server_key1, self.settings.server_key2):
+            self.prevented_key1_press = False
+            got_next_client = self._maybe_get_next_client(key_code=event.code)
+            if (
+                    event.value == KeyEventType.KEY_UP and
+                    event.code == self.settings.server_key1 and
+                    not got_next_client and
+                    not self.key2_down
+            ):  # key1 up without it being part of our key sequence
+                # create a press event and then allow this release event to go through
+                self._send_event_to_client(self._make_key1_press_from_event(event))
+            elif (
+                    event.code == self.settings.server_key2 and
+                    not got_next_client and
+                    not self.key1_down and
+                    not self.keys_activated
+            ):  # key2 up/down event without key2 being pressed first
+                pass  # allow event
+            else:  # otherwise prevent the key event from going through.
+                if event.code == self.settings.server_key1 and event.value == 1:
+                    self.prevented_key1_press = True
+
+                return False
+        elif self.prevented_key1_press:
+            # we prevented the key1 press event, but now have an unrelated event.
+            # send the key1 press that was prevented earlier, so that it can be part
+            # of some other key sequence caught by another app.
+            self._send_event_to_client(self._make_key1_press_from_event(event))
+            self.prevented_key1_press = False
+
+        return True
+
+    def handle_events(self, device):
+        """Start loop to listen for device's events."""
+        device.grab()
+        while self.running:
+            read_ready, _, _ = select([device.fd], [], [], 0.1)  # 0.1 second timeout
+            if not read_ready:
+                continue
+
+            for event in device.read():
+                if not self.running:
+                    break
+
+                if self._process_event(event):
+                    self._send_event_to_client(event)
+
+        device.ungrab()
+        device.close()

--- a/nkms/core/server.py
+++ b/nkms/core/server.py
@@ -1,36 +1,27 @@
-import select
-import json
-from enum import IntEnum
 from typing import Final
 
-import evdev
-import socket
-import threading
+from evdev import InputDevice, list_devices, ecodes
+from json import dumps as json_dumps
 from time import time
+from threading import Event, Lock, Thread
 
+from nkms.core.event_handler import EventHandler
 from nkms.core.settings import NkmsSettings
 from nkms.utils.udp_socket import UdpSocket
 
-client_lock = threading.Lock()
+client_lock = Lock()
 SERVER_CLIENT_INDEX: Final = -1
 CLIENT_ACTIVITY_TIMEOUT: Final = 5  # drop clients after 5 seconds with no pings.
 
-class KeyEventType(IntEnum):
-    KEY_UP = 0
-    KEY_DOWN = 1
-    KEY_REPEAT = 2
 
-
-def get_km_devices() -> list[evdev.InputDevice]:
+def get_km_devices() -> list[InputDevice]:
     """Get devices that have capabilities that look like a keyboard or mouse."""
     devs = []
-    all_devices = [evdev.InputDevice(path) for path in evdev.list_devices()]
-    for dev in all_devices:
+    for dev in [InputDevice(path) for path in list_devices()]:
         cap = dev.capabilities()
-        ec = evdev.ecodes
-        if ec.EV_KEY in cap:
-            keys = cap[ec.EV_KEY]
-            if ec.BTN_LEFT in keys or (ec.KEY_A in keys and ec.KEY_Z in keys):
+        if ecodes.EV_KEY in cap:
+            keys = cap[ecodes.EV_KEY]
+            if ecodes.BTN_LEFT in keys or (ecodes.KEY_A in keys and ecodes.KEY_Z in keys):
                 devs.append(dev)
     return devs
 
@@ -40,15 +31,14 @@ def get_capabilities(devices: list) -> dict:
     new_caps = {}
     for dev in devices:
         dev_caps = dev.capabilities()
-        for k in dev_caps.keys():
-            if k not in new_caps.keys():
-                new_caps[k] = []
-
+        for k, values in dev_caps.items():
             if k == 0:
                 continue
 
-            a = dev_caps[k]
-            for v in a:
+            if k not in new_caps:
+                new_caps[k] = []
+
+            for v in values:
                 if v not in new_caps[k]:
                     new_caps[k].append(v)
 
@@ -59,180 +49,46 @@ class NkmsServer:
 
     def __init__(self):
         self.settings = NkmsSettings()
-        self.keys_activated = False
-        self.key1_down = False
-        self.key2_down = False
-        #self.grab_status = defaultdict(lambda : False)
+        self.event_handler = None
         self.devices = []
-        self.clients = []
-        self.client_index = SERVER_CLIENT_INDEX
         self.running = False
         self.threads = []
         self.activity: dict[str, float] = {}  # dict mapping clients to their last active timestamp
-        self.stop_event = threading.Event()
-        self.uinput = None
+        self.stop_event = Event()
         self.capabilities = {}
-
-    def get_next_client(self):
-        """Set socket_index to next value to cycle through outputs."""
-        if self.client_index >= len(self.clients) - 1:
-            self.client_index = SERVER_CLIENT_INDEX
-        else:
-            self.client_index = self.client_index + 1
-
-    def _maybe_get_next_client(self, key_code: int) -> bool:
-        """Go to next client if switch key sequence has been pressed."""
-        got_next_client = False
-        if key_code == self.settings.server_key1:
-            if (
-                self.key1_down is True and  # key1 is releasing
-                (
-                    self.settings.server_key2 == 0 or  # key2 is undefined or
-                    (self.keys_activated is True and self.key2_down is False)  # key2 was pressed and released
-                )
-            ):
-                # without key2: key1 was pressed, and is now releasing
-                # with key2: key1 was pressed, key2 was pressed, key2 was released, key1 is now releasing
-                self.get_next_client()
-                self.keys_activated = False
-                got_next_client = True
-
-            self.key1_down = not self.key1_down
-
-        elif key_code == self.settings.server_key2:
-            if self.key2_down is True and self.keys_activated is True and self.key1_down is False:
-                # key1 was pressed, key2 was pressed, key1 released, now key2 is releasing
-                self.get_next_client()
-                self.keys_activated = False
-                got_next_client = True
-
-            if self.key1_down is True:
-                self.keys_activated = True
-
-            self.key2_down = not self.key2_down
-
-        return got_next_client
-
-    def send_event_to_client(self, event, sock, data_port) -> None:
-        """Send event to client."""
-        if self.client_index == SERVER_CLIENT_INDEX:
-            self.uinput.write_event(event)
-            self.uinput.syn()
-            return
-
-        with client_lock:  # Protect clients list access
-            if self.clients:
-                client = self.clients[self.client_index]
-                try:
-                    sock.send_string_to(
-                        string=f"{json.dumps([event.type, event.code, event.value])}\n",
-                        to=(client, data_port),
-                    )
-                except OSError as e:
-                    print(f'Error sending to {client}: {e!s}')
-                    self.clients.remove(client)
-                    self.get_next_client()
-
-    def _make_key1_press_from_event(self, event: evdev.InputEvent) -> evdev.InputEvent:
-        """Create a key1 press event to immediately precede the given event."""
-        return evdev.InputEvent(
-            sec=event.sec,
-            usec=event.usec - 1,
-            type=evdev.ecodes.EV_KEY,
-            code=self.settings.server_key1,
-            value=KeyEventType.KEY_DOWN,
-        )
-
-    def handle_events(self, device):
-        """Start loop to listen for device's events."""
-        sock = UdpSocket()
-        data_port = self.settings.server_port + 1  # just use the next higher port
-        device.grab()
-        prevented_key1_press = False
-
-        while self.running:
-            read_ready, _, _ = select.select([device.fd], [], [], 0.1)  # 0.1 second timeout
-            if not read_ready:
-                continue
-
-            for event in device.read():
-                if not self.running:
-                    break
-
-                if (
-                    event.type == evdev.ecodes.EV_KEY and
-                    event.value in (KeyEventType.KEY_UP, KeyEventType.KEY_DOWN)
-                ):
-                    if event.code in (self.settings.server_key1, self.settings.server_key2):
-                        prevented_key1_press = False
-                        got_next_client = self._maybe_get_next_client(key_code=event.code)
-                        if (
-                            event.value == KeyEventType.KEY_UP and
-                            event.code == self.settings.server_key1 and
-                            not got_next_client and
-                            not self.key2_down
-                        ):  # key1 up without it being part of our key sequence
-                            # create a press event and then allow this release event to go through
-                            self.send_event_to_client(self._make_key1_press_from_event(event), sock, data_port)
-                        elif (
-                            event.code == self.settings.server_key2 and
-                            not got_next_client and
-                            not self.key1_down and
-                            not self.keys_activated
-                        ):  # key2 up/down event without key2 being pressed first
-                            pass  # allow event
-                        else:  # otherwise prevent the key event from going through.
-                            if event.code == self.settings.server_key1 and event.value == 1:
-                                prevented_key1_press = True
-
-                            continue
-                    elif prevented_key1_press:
-                        # we prevented the key1 press event, but now have an unrelated event.
-                        # send the key1 press that was prevented earlier, so that it can be part
-                        # of some other key sequence caught by another app.
-                        self.send_event_to_client(self._make_key1_press_from_event(event), sock, data_port)
-                        prevented_key1_press = False
-
-                self.send_event_to_client(event, sock, data_port)
-
-        device.close()
 
     def maybe_drop_inactive_clients(self):
         now = time()
-        with client_lock:
-            for client in self.clients:
-                if client not in self.activity:
-                    print("Warning: have client with no activity timestamp!")
-                    continue  # shouldn't ever happen
+        inactive_clients = []
+        for client in self.activity:
+            if now - self.activity[client] >= CLIENT_ACTIVITY_TIMEOUT:
+                inactive_clients.append(client)
 
-                if now - self.activity[client] >= CLIENT_ACTIVITY_TIMEOUT:
-                    print(f'Dropping inactive client: {client}')
-                    should_get_next = self.client_index == self.clients.index(client)
-                    self.clients.remove(client)
-                    if should_get_next:
-                        self.get_next_client()
+        for client in inactive_clients:
+            print(f'Dropping inactive client: {client}')
+            self.activity.pop(client, None)
+            self.event_handler.remove_client(client)
 
     def maybe_process_client_data(self, sock: UdpSocket) -> None:
         try:
             data, (address, port) = sock.recvfrom(1024)
-        except socket.timeout:
+        except TimeoutError:
             return
 
-        if data == b'ping':  # update active timestamp for this client
+        if data == b'ping':
             sock.send_string_to(string='pong', to=(address, port))
-            self.activity[address] = time()
+            if address in self.activity:  # update activity if the device has been initialized.
+                self.activity[address] = time()
         elif data == b'get devices':
             sock.send_string_to(
-                string=f"{json.dumps(self.capabilities)}\n",
+                string=f"{json_dumps(self.capabilities)}\n",
                 to=(address, port),
             )
             print(f"Sent device list to: {address}")
         elif data == b'initialized':
-            with client_lock:
-                if address not in self.clients:  # prevent duplicate entries
-                    self.clients.append(address)
-                    self.activity[address] = time()
-                    print(f"Initialized new client: {address}")
+            self.activity[address] = time()  # add device address to the activity dict
+            self.event_handler.add_client(address)
+            print(f"Initialized new client: {address}")
 
     def listen_for_client_data(self, address, port):
         sock = UdpSocket(timeout=2)
@@ -247,16 +103,19 @@ class NkmsServer:
         self.running = True
         self.devices = get_km_devices()
         self.capabilities = get_capabilities(self.devices)
-        self.uinput = evdev.UInput(self.capabilities, name='NetKMSwitch Keyboard and Mouse')
+        self.event_handler = EventHandler(
+            settings=self.settings,
+            device_capabilities=self.capabilities,
+        )
         self.threads = []
         for device in self.devices:
             print(f'Loading input device: {device.path}')
-            self.threads.append(threading.Thread(
-                target=self.handle_events,
-                args=(evdev.InputDevice(device.path),),
+            self.threads.append(Thread(
+                target=self.event_handler.handle_events,
+                args=(device,),
             ))
 
-        self.threads.append(threading.Thread(
+        self.threads.append(Thread(
             target=self.listen_for_client_data,
             args=(
                 self.settings.server_address,
@@ -273,6 +132,8 @@ class NkmsServer:
 
     def stop(self):
         self.running = False
+        if self.event_handler:
+            self.event_handler.running = False
         self.stop_event.set()
         for thread in self.threads:
             thread.join()

--- a/nkms/core/server.py
+++ b/nkms/core/server.py
@@ -1,18 +1,27 @@
 import select
 import json
+from enum import IntEnum
+from typing import Final
 
 import evdev
 import socket
 import threading
-from time import sleep, time
+from time import time
 
 from nkms.core.settings import NkmsSettings
 from nkms.utils.udp_socket import UdpSocket
 
 client_lock = threading.Lock()
+SERVER_CLIENT_INDEX: Final = -1
+CLIENT_ACTIVITY_TIMEOUT: Final = 5  # drop clients after 5 seconds with no pings.
+
+class KeyEventType(IntEnum):
+    KEY_UP = 0
+    KEY_DOWN = 1
+    KEY_REPEAT = 2
 
 
-def get_km_devices() -> list:
+def get_km_devices() -> list[evdev.InputDevice]:
     """Get devices that have capabilities that look like a keyboard or mouse."""
     devs = []
     all_devices = [evdev.InputDevice(path) for path in evdev.list_devices()]
@@ -24,6 +33,7 @@ def get_km_devices() -> list:
             if ec.BTN_LEFT in keys or (ec.KEY_A in keys and ec.KEY_Z in keys):
                 devs.append(dev)
     return devs
+
 
 def get_capabilities(devices: list) -> dict:
     """Get capabilities dict for the provided devices."""
@@ -52,42 +62,27 @@ class NkmsServer:
         self.keys_activated = False
         self.key1_down = False
         self.key2_down = False
-        self.grabbing = False
-        self.grab_status = {}
+        #self.grab_status = defaultdict(lambda : False)
         self.devices = []
         self.clients = []
-        self.client_index = -1
+        self.client_index = SERVER_CLIENT_INDEX
         self.running = False
         self.threads = []
         self.activity: dict[str, float] = {}  # dict mapping clients to their last active timestamp
-
-    def do_grabbing(self, grab_dev):
-        """Grab / Ungrab device depending on value of `grabbing`.
-        Also set status in `grab_status` since there's not an easy way to check a devices grab status.
-        """
-        if (dev_path := grab_dev.path) not in self.grab_status:
-            self.grab_status[dev_path] = False
-
-        if self.grabbing and self.grab_status[dev_path] is False:
-            grab_dev.grab()
-            self.grab_status[dev_path] = True
-        elif not self.grabbing and self.grab_status[dev_path] is True:
-            grab_dev.ungrab()
-            self.grab_status[dev_path] = False
+        self.stop_event = threading.Event()
+        self.uinput = None
+        self.capabilities = {}
 
     def get_next_client(self):
         """Set socket_index to next value to cycle through outputs."""
         if self.client_index >= len(self.clients) - 1:
-            self.client_index = -1
-            self.grabbing = False
+            self.client_index = SERVER_CLIENT_INDEX
         else:
             self.client_index = self.client_index + 1
-            self.grabbing = True
 
-    def _maybe_get_next_client(self, key_code: int, key_down: bool) -> None:
-        """Go to next client if switch key sequence has been pressed.
-        Returns True if going to next client, otherwise returns False.
-        """
+    def _maybe_get_next_client(self, key_code: int) -> bool:
+        """Go to next client if switch key sequence has been pressed."""
+        got_next_client = False
         if key_code == self.settings.server_key1:
             if (
                 self.key1_down is True and  # key1 is releasing
@@ -100,6 +95,7 @@ class NkmsServer:
                 # with key2: key1 was pressed, key2 was pressed, key2 was released, key1 is now releasing
                 self.get_next_client()
                 self.keys_activated = False
+                got_next_client = True
 
             self.key1_down = not self.key1_down
 
@@ -108,17 +104,51 @@ class NkmsServer:
                 # key1 was pressed, key2 was pressed, key1 released, now key2 is releasing
                 self.get_next_client()
                 self.keys_activated = False
+                got_next_client = True
 
             if self.key1_down is True:
                 self.keys_activated = True
 
             self.key2_down = not self.key2_down
 
+        return got_next_client
+
+    def send_event_to_client(self, event, sock, data_port) -> None:
+        """Send event to client."""
+        if self.client_index == SERVER_CLIENT_INDEX:
+            self.uinput.write_event(event)
+            self.uinput.syn()
+            return
+
+        with client_lock:  # Protect clients list access
+            if self.clients:
+                client = self.clients[self.client_index]
+                try:
+                    sock.send_string_to(
+                        string=f"{json.dumps([event.type, event.code, event.value])}\n",
+                        to=(client, data_port),
+                    )
+                except OSError as e:
+                    print(f'Error sending to {client}: {e!s}')
+                    self.clients.remove(client)
+                    self.get_next_client()
+
+    def _make_key1_press_from_event(self, event: evdev.InputEvent) -> evdev.InputEvent:
+        """Create a key1 press event to immediately precede the given event."""
+        return evdev.InputEvent(
+            sec=event.sec,
+            usec=event.usec - 1,
+            type=evdev.ecodes.EV_KEY,
+            code=self.settings.server_key1,
+            value=KeyEventType.KEY_DOWN,
+        )
 
     def handle_events(self, device):
         """Start loop to listen for device's events."""
         sock = UdpSocket()
         data_port = self.settings.server_port + 1  # just use the next higher port
+        device.grab()
+        prevented_key1_press = False
 
         while self.running:
             read_ready, _, _ = select.select([device.fd], [], [], 0.1)  # 0.1 second timeout
@@ -129,104 +159,121 @@ class NkmsServer:
                 if not self.running:
                     break
 
-                self.do_grabbing(device)
-                data = [event.type, event.code, event.value]
-                with client_lock:  # Protect clients list access
-                    if self.clients and self.client_index >= 0:
-                        client = self.clients[self.client_index]
-                        try:
-                            sock.send_string_to(
-                                string=f"{json.dumps(data)}\n",
-                                to=(client, data_port),
-                            )
-                        except OSError as e:
-                            print(f'Error sending to {client}: {e!s}')
-                            self.clients.remove(client)
-                            self.get_next_client()
-
                 if (
                     event.type == evdev.ecodes.EV_KEY and
-                    (event.value == 0 or event.value == 1)  # key up or down, no repeat
+                    event.value in (KeyEventType.KEY_UP, KeyEventType.KEY_DOWN)
                 ):
-                    self._maybe_get_next_client(key_code=event.code, key_down=(event.value == 1))
+                    if event.code in (self.settings.server_key1, self.settings.server_key2):
+                        prevented_key1_press = False
+                        got_next_client = self._maybe_get_next_client(key_code=event.code)
+                        if (
+                            event.value == KeyEventType.KEY_UP and
+                            event.code == self.settings.server_key1 and
+                            not got_next_client and
+                            not self.key2_down
+                        ):  # key1 up without it being part of our key sequence
+                            # create a press event and then allow this release event to go through
+                            self.send_event_to_client(self._make_key1_press_from_event(event), sock, data_port)
+                        elif (
+                            event.code == self.settings.server_key2 and
+                            not got_next_client and
+                            not self.key1_down and
+                            not self.keys_activated
+                        ):  # key2 up/down event without key2 being pressed first
+                            pass  # allow event
+                        else:  # otherwise prevent the key event from going through.
+                            if event.code == self.settings.server_key1 and event.value == 1:
+                                prevented_key1_press = True
+
+                            continue
+                    elif prevented_key1_press:
+                        # we prevented the key1 press event, but now have an unrelated event.
+                        # send the key1 press that was prevented earlier, so that it can be part
+                        # of some other key sequence caught by another app.
+                        self.send_event_to_client(self._make_key1_press_from_event(event), sock, data_port)
+                        prevented_key1_press = False
+
+                self.send_event_to_client(event, sock, data_port)
 
         device.close()
 
-    def listen_for_clients(self, address, port):
+    def maybe_drop_inactive_clients(self):
+        now = time()
+        with client_lock:
+            for client in self.clients:
+                if client not in self.activity:
+                    print("Warning: have client with no activity timestamp!")
+                    continue  # shouldn't ever happen
+
+                if now - self.activity[client] >= CLIENT_ACTIVITY_TIMEOUT:
+                    print(f'Dropping inactive client: {client}')
+                    should_get_next = self.client_index == self.clients.index(client)
+                    self.clients.remove(client)
+                    if should_get_next:
+                        self.get_next_client()
+
+    def maybe_process_client_data(self, sock: UdpSocket) -> None:
+        try:
+            data, (address, port) = sock.recvfrom(1024)
+        except socket.timeout:
+            return
+
+        if data == b'ping':  # update active timestamp for this client
+            sock.send_string_to(string='pong', to=(address, port))
+            self.activity[address] = time()
+        elif data == b'get devices':
+            sock.send_string_to(
+                string=f"{json.dumps(self.capabilities)}\n",
+                to=(address, port),
+            )
+            print(f"Sent device list to: {address}")
+        elif data == b'initialized':
+            with client_lock:
+                if address not in self.clients:  # prevent duplicate entries
+                    self.clients.append(address)
+                    self.activity[address] = time()
+                    print(f"Initialized new client: {address}")
+
+    def listen_for_client_data(self, address, port):
         sock = UdpSocket(timeout=2)
         sock.bind((address, port))
-        print(f"Server listening for clients on port {port}")
-
+        print(f"Listening for clients on port {port}")
         while self.running:
-            # Check for inactive clients
-            now = time()
-            with client_lock:
-                for client in self.clients:
-                    if client not in self.activity:
-                        print("Warning: have client with no activity timestamp!")
-                        continue  # shouldn't ever happen
-
-                    if now - self.activity[client] > 4:
-                        print(f'Dropping inactive client: {client}')
-                        get_next = self.client_index == self.clients.index(client)
-                        self.clients.remove(client)
-                        if get_next:
-                            self.get_next_client()
-
-            # Receive any pending data
-            try:
-                data, addr_port = sock.recvfrom(1024)
-            except socket.timeout:
-                continue
-
-            addr = addr_port[0]
-            if data == b'ping':  # update active timestamp for this client
-                sock.send_string_to(string='pong', to=addr_port)
-                self.activity[addr] = time()
-            if data == b"get devices":
-                sock.send_string_to(
-                    string=f"{json.dumps(get_capabilities(self.devices))}\n",
-                    to=addr_port,
-                )
-                print(f"Sent device list to: {addr}")
-            elif data == b'initialized':
-                with client_lock:
-                    if addr not in self.clients:  # prevent duplicate entries
-                        self.clients.append(addr)
-                        self.activity[addr] = time()
-                        print(f"Initialized new client: {addr}")
+            self.maybe_drop_inactive_clients()
+            self.maybe_process_client_data(sock)
 
     def run(self):
         print('Starting NKMS Server ...')
-        port = self.settings.server_port
-        address = self.settings.server_address
-
         self.running = True
-
-        print('Loading input devices ...')
         self.devices = get_km_devices()
+        self.capabilities = get_capabilities(self.devices)
+        self.uinput = evdev.UInput(self.capabilities, name='NetKMSwitch Keyboard and Mouse')
         self.threads = []
         for device in self.devices:
             print(f'Loading input device: {device.path}')
-            km_dev = evdev.InputDevice(device.path)
-            thread = threading.Thread(target=self.handle_events, args=(km_dev,))
-            self.threads.append(thread)
+            self.threads.append(threading.Thread(
+                target=self.handle_events,
+                args=(evdev.InputDevice(device.path),),
+            ))
 
-        print('Listening for client connections ...')
-        tcp_thread = threading.Thread(target=self.listen_for_clients, args=(address, port,))
-        self.threads.append(tcp_thread)
+        self.threads.append(threading.Thread(
+            target=self.listen_for_client_data,
+            args=(
+                self.settings.server_address,
+                self.settings.server_port,
+            ),
+        ))
 
         for thread in self.threads:
             thread.daemon = True
             thread.start()
 
         print('NKMS Server Started')
-
-        while self.running:
-            sleep(1)
+        self.stop_event.wait()
 
     def stop(self):
         self.running = False
+        self.stop_event.set()
         for thread in self.threads:
             thread.join()
 

--- a/nkms/core/settings.py
+++ b/nkms/core/settings.py
@@ -9,9 +9,9 @@ class NkmsSettings:
         # Defaults
         self.mode = "Client"
         self.client_server = ""
-        self.client_port = "4777"
+        self.client_port = 4777
         self.server_address = "0.0.0.0"
-        self.server_port = "4777"
+        self.server_port = 4777
         self.server_key1 = 125
         self.server_key2 = 41
         # Load saved values


### PR DESCRIPTION
* Fixes an issue where the keys in the next client key sequence were still being passed to the clients. Causing weird things where the press happened on one machine and the release happened on the other, etc.
    - Changes how events are handled on the server, from only gabbing input when a client is active to always grabbing and simply passing through to a virtual input device when the server is active, allowing to completely prevent the hotkey events from being seen by other apps.
* Refactors the event handling logic into a separate class.